### PR TITLE
Add preserveFilenames option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ var includeFolder = require('include-folder'),
 This only include files that start with 'a'
 
 Filter parameters defaults to /^[^.].*$/, which include every file
-in the folder, except hidden ones (these that has a name starting with dot). 
+in the folder, except hidden ones (these that has a name starting with dot).
 
+## Preserve filenames
 
+To prevent normalization and stripping of the extension in the result object, the `preserveFilenames` option can be used:
+
+```javascript
+includeFolder('./www', null, { preserveFilenames: true });
+```
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style.
@@ -50,6 +56,6 @@ Add unit tests for any new or changed functionality.
 
 
 ## License
-Copyright (c) 2013 parroit  
+Copyright (c) 2013 parroit
 Licensed under the MIT license.
 

--- a/lib/include-folder.js
+++ b/lib/include-folder.js
@@ -11,7 +11,7 @@
 var fs = require("fs");
 
 function includeFolder(folderName, filter, options) {
-    folderName = folderName.replace(/^\//, '');
+    folderName = folderName.replace(/\/$/, '');
 
     if (!filter) {
         filter = /^[^.].*$/;

--- a/lib/include-folder.js
+++ b/lib/include-folder.js
@@ -8,25 +8,25 @@
 
 'use strict';
 
-var _ = require("lodash"),
-    fs = require("fs");
+var fs = require("fs");
 
-function includeFolder(folderName, filter) {
-    if (folderName.charAt(folderName.length - 1) === "/") {
-        folderName = folderName.substring(0, folderName.length - 1);
-    }
+function includeFolder(folderName, filter, options) {
+    folderName = folderName.replace(/^\//, '');
 
     if (!filter) {
         filter = /^[^.].*$/;
     }
 
-    var source = includeFolder._testHook.buildSource(folderName, filter);
+    if (typeof options !== 'object') {
+        options = {};
+    }
+
+    var source = includeFolder.buildSource(folderName, filter, options);
 
     return (new Function("require", "__dirname", source))(require, folderName);
-
 }
 
-function normalize(name) {
+includeFolder.normalize = function(name) {
     var chars = [];
     var nextUpper = false;
     var i = 0,
@@ -45,19 +45,23 @@ function normalize(name) {
     return name;
 }
 
-function stripExtension(fileName) {
-    if (fileName.charAt(0) === ".")
-        fileName = fileName.substring(1);
-
-    return fileName.replace(/\.[^/.]+$/, "");
+includeFolder.stripExtension = function(fileName) {
+    return fileName.replace(/^\./, "").replace(/\.[^/.]+$/, "");
 }
 
-function buildSource(folderName, filter) {
+includeFolder.buildSource = function(folderName, filter, options) {
     var files = fs.readdirSync(folderName);
     var allProps = {};
     filter = filter.test.bind(filter);
-    var fields = _(files).filter(filter).map(function(fileName) {
-        var name = normalize(stripExtension(fileName));
+    var fields = files.filter(filter).map(function(fileName) {
+        var name = includeFolder.normalize(
+            includeFolder.stripExtension(fileName, options),
+            options
+        );
+
+        if (options && options.preserveFilenames === true) {
+            name = fileName;
+        }
 
         if (name in allProps) {
             allProps[name]++;
@@ -66,22 +70,13 @@ function buildSource(folderName, filter) {
             allProps[name] = 0;
         }
 
-        return 'self.' + name + ' = fs.readFileSync("' + folderName + '/' + fileName + '","utf8");';
-    }).value();
-
+        return 'self["' + name + '"] = fs.readFileSync("' + folderName + '/' + fileName + '","utf8");';
+    });
 
     return "var self={}," +
         "fs = require('fs');\n" +
         fields.join("\n") +
         "\nreturn self";
 }
-
-
-includeFolder._testHook = {
-    buildSource: buildSource,
-    normalize: normalize,
-    stripExtension: stripExtension
-};
-
 
 module.exports = includeFolder;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,5 @@
     "require",
     "readFileSync"
   ],
-  "dependencies": {
-    "lodash": "~2.4.1"
-  }
+  "dependencies": {}
 }

--- a/test/include-folder_test.js
+++ b/test/include-folder_test.js
@@ -1,25 +1,24 @@
 'use strict';
 
 var expect = require("expect.js"),
-    _ = require("lodash"),
     includeFolder = require("../lib/include-folder");
 
 
 describe("normalize", function() {
     it("handles .DS_Store", function() {
-        var normalized = includeFolder._testHook.normalize(".DS_Store");
+        var normalized = includeFolder.normalize(".DS_Store");
         expect(normalized).to.be.equal("DS_Store");
     });
 });
 
 describe("stripExtension", function() {
     it("remove extension", function() {
-        var normalized = includeFolder._testHook.stripExtension("test.txt");
+        var normalized = includeFolder.stripExtension("test.txt");
         expect(normalized).to.be.equal("test");
     });
 
     it("handles hidden files", function() {
-        var normalized = includeFolder._testHook.stripExtension(".txt");
+        var normalized = includeFolder.stripExtension(".txt");
         expect(normalized).to.be.equal("txt");
     });
 });
@@ -28,11 +27,7 @@ describe("stripExtension", function() {
 
 describe("include_folder", function() {
     it("is defined", function() {
-        expect(includeFolder).to.be.an('function');
-    });
-
-    it("has test hook", function() {
-        expect(includeFolder._testHook).to.be.an('object');
+        expect(includeFolder).to.be.a('function');
     });
 
     function moduleCheck(folderModule, expectedCount) {
@@ -40,9 +35,8 @@ describe("include_folder", function() {
             expect(folderModule).to.be.an('object');
         });
 
-
         it("has a property for each file", function() {
-            expect(_.keys(folderModule).length).to.be.equal(expectedCount);
+            expect(Object.keys(folderModule).length).to.be.equal(expectedCount);
         });
 
         it("extension is stripped from file names", function() {
@@ -66,7 +60,7 @@ describe("include_folder", function() {
         var source,
             folderModule;
 
-        source = includeFolder._testHook.buildSource("./test/files", /^[^.].*$/),
+        source = includeFolder.buildSource("./test/files", /^[^.].*$/),
         console.log(source)
         folderModule = (new Function("require", "__dirname", source))(require, __dirname + "/files/");
 
@@ -75,19 +69,30 @@ describe("include_folder", function() {
 
 
     describe("returned object", function() {
-
-
         var folderModule = includeFolder("./test/files");
 
         moduleCheck(folderModule, 3);
     });
 
     describe("work with hidden files", function() {
-
-
         var folderModule = includeFolder("./test/files", /.*/);
 
         moduleCheck(folderModule, 4);
+    });
+
+    describe("when the preserveFilenames option is true", function() {
+        beforeEach(function(){
+            this.folderModule = includeFolder("./test/files", null, { preserveFilenames: true });
+        });
+
+        it("extension is not stripped from file names", function() {
+            expect("file1.txt" in this.folderModule).to.be.equal(true);
+            expect("file1.check" in this.folderModule).to.be.equal(true);
+        });
+
+        it("filename is not normalized", function() {
+            expect("file-3-other&file.txt" in this.folderModule).to.be.equal(true);
+        });
     });
 
 });


### PR DESCRIPTION
 - Removes the _testHook bit. Keeping the private(ish) methods on the
 exported function achieves the same goal.
 - Adds a test for preserveFilenames
 - Removes lodash from the project. All the helpers used are available
 in the node runtime.